### PR TITLE
Update dependencies for compatibility and features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,13 +744,17 @@ dependencies = [
 
 [[package]]
 name = "icloud-album-rs"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbe63406794e9ef18f105aeaa29d9f40b59c64312af8360382895aa6687e88"
+checksum = "994ddc196ee524ca44a5adc1507c2d1d63bdfed8099fdaa92b5d110a18fc95a6"
 dependencies = [
+ "env_logger",
+ "log",
+ "rand 0.8.5",
  "reqwest",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
 ]
 
@@ -1686,6 +1690,26 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tinystr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icloudAlbum2hugo"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 authors = ["Harper Reed <harper@harper.website>"]
 description = "A command-line tool that syncs photos from iCloud Shared Albums to a Hugo site"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1.0"
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"
-icloud-album-rs = "0.1.0"
+icloud-album-rs = "0.3.0"
 url = "2.5"
 mockito = "1.3"
 chrono = { version = "0.4", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "icloudAlbum2hugo"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 authors = ["Harper Reed <harper@harper.website>"]
 description = "A command-line tool that syncs photos from iCloud Shared Albums to a Hugo site"


### PR DESCRIPTION
# Pull Request: Update Dependencies and Version Bump

### Summary
This pull request introduces significant updates to the dependencies and versions in the `Cargo.toml` and `Cargo.lock` files for the `icloudAlbum2hugo` project. The main goal of this update is to keep the project aligned with the latest improvements in the libraries used and fix potential bugs that were mysteriously involved with Elvis. Yes, that's right. This is all his fault.

### Why these changes?
Keeping library dependencies up to date ensures better performance, security, and access to new features. Some of the previous libraries were outdated, which could lead to bugs or security vulnerabilities. If we want our sync tool to be as smooth as someone’s hips during a 1950s dance-off, we need to iron these issues out.

### Changes made:
- **Cargo.lock**
  - Updated `icloud-album-rs` from version `0.1.0` to `0.3.0`.
  - Added new dependencies: 
    - `env_logger`
    - `log`
    - `rand 0.8.5`
    - `thiserror`
  - Updated checksum matches for the packages that got version bumps.
  - Added `thiserror` and `thiserror-impl` packages.

- **Cargo.toml**
  - Bumped package version from `0.2.0` to `0.3.0`.
  - Updated dependency version of `icloud-album-rs` to `0.3.0`.

### Closed Issues
- Some dependencies were causing bugs, but only Elvis knows what the hell went wrong. Anyone seeing him can ask why he couldn’t keep his promise to keep those libraries straightened out.

### In Conclusion
Alright, let's put the Elvis conspiracy theory aside, even though it seems oddly plausible. There's a lot of potential improvement packed in these updates, and we must always strive to keep our dependencies and codebases up to speed. So, let's merge this bad boy and keep our tools in top-notch condition!

#### Haiku
Dependencies rise,  
Version bumps like Elvis spins,  
Code dances anew.