### PR TITLE
Update dependencies and ignore custom file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ album_data_debug.txt
 prompt_plan.md
 output.txt
 
+custom/data.yaml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "icloudAlbum2hugo"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",


### PR DESCRIPTION
# Pull Request: Update .gitignore and Cargo.lock

## Summary
This pull request implements updates to the `.gitignore` and `Cargo.lock` files. The changes include the addition of a new entry to the `.gitignore` and a version bump in the Cargo.lock, which is necessary for keeping our dependencies in check.

## Why These Changes?
The `.gitignore` file has been updated to prevent committing the `data.yaml` file found in the `custom` directory. This change ensures that sensitive configuration data or environment-specific settings do not inadvertently make their way into version control, which is always a good idea—unless you want to make your life a hell of a lot harder.

Moreover, updating the version of the package in `Cargo.lock` is essential for ensuring we are using the latest features and any critical bug fixes provided by the newer version. Speaking of bugs, let's face it: Elvis may have left the building, but he sure left behind some code that occasionally seems like a bloody mess.

## Changes Made
- **.gitignore**
  - Added `custom/data.yaml` to the ignore list.

- **Cargo.lock**
  - Updated the version of the package `icloudAlbum2hugo` from `0.2.0` to `0.4.0`.

## Closed Issues
- None in particular, but the changes may indirectly address some of those pesky issues we've been having.

Remember, if something goes wrong after this, we can always just blame Elvis! Damn that guy!

## Haiku
Files ignored, updated,  
Dependency's new version,  
Elvis, what a mess!